### PR TITLE
Fix logpoint

### DIFF
--- a/src/els_dap_general_provider.erl
+++ b/src/els_dap_general_provider.erl
@@ -1043,6 +1043,8 @@ safe_eval(ProjectNode, Debugged, Expression, Update) ->
     case Update of
         update ->
             ok;
+        _ when Return == 'Parse error' ->
+            ok;
         no_update ->
             receive
                 {int_cb, Debugged} -> ok

--- a/src/els_dap_sup.erl
+++ b/src/els_dap_sup.erl
@@ -106,7 +106,14 @@ noop_group_leader() ->
             case Message of
                 {io_request, From, ReplyAs, getopts} ->
                     From ! {io_reply, ReplyAs, []};
-                {io_request, From, ReplyAs, _} ->
+                {io_request, From, ReplyAs, Converted} ->
+                    case Converted of
+                        {_, _, _, _, [Format, Args]} ->
+                            Output = unicode:characters_to_binary(io_lib:format(Format, Args)),
+                            els_dap_server:send_event(<<"output">>,
+                                #{<<"output">> => Output, <<"category">> => <<"stdout">>});
+                        _ -> ok
+                    end,
                     From ! {io_reply, ReplyAs, ok};
                 _ ->
                     ok


### PR DESCRIPTION
1. {int_cb, Debugged} is never received when Return == 'Parse error', which causes the program to permanently pause.
2. Logexpr matches the expression inside {} as the variable that needs to be replaced.
3. When <<"context">>=<<"repl">>, the argument does not contain <<"frameId">>, use a new function branch.