### PR TITLE
Add optional StripSourcePrefix option to launch config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Escriptize Debugger
       run: rebar3 escriptize
     - name: Store Debugger Escript
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: els_dap
         path: _build/default/bin/els_dap
@@ -53,7 +53,7 @@ jobs:
     - name: Run CT Tests
       run: rebar3 ct
     - name: Store CT Logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ct-logs
         path: _build/test/logs
@@ -65,7 +65,7 @@ jobs:
       run: rebar3 edoc
       if: ${{ matrix.otp-version == '24' }}
     - name: Publish Documentation
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: edoc
         path: |
@@ -90,7 +90,7 @@ jobs:
     - name: Run CT Tests
       run: rebar3 ct
     - name: Store CT Logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ct-logs
         path: _build/test/logs

--- a/src/els_dap_general_provider.erl
+++ b/src/els_dap_general_provider.erl
@@ -1150,4 +1150,9 @@ force_delete_breakpoints(ProjectNode, Module, Breakpoints) ->
 
 -spec strip_suffix(binary(), binary()) -> binary().
 strip_suffix(Path, Suffix) ->
-    binary:part(Path, 0, byte_size(Path) - binary:longest_common_suffix([Path, Suffix])).
+    SuffixSize = byte_size(Suffix),
+    PathSize = byte_size(Path),
+    case binary:part(Path, {PathSize, -SuffixSize}) of
+        Suffix -> binary:part(Path, {0, PathSize - SuffixSize});
+        _ -> Path
+    end.


### PR DESCRIPTION
In certain scenarios - most notoriously when working in the context of a mono-repo - the current directory (i.e. the workspaceFolder` does not coincide with the root of the repository, which `Source`s are relative to.

To support those scenarios, add an optional `StripSourcePrefix` config option, so that the resulting paths are correct.